### PR TITLE
Feature/14 update payara versionUpdate dependencies and enhance Jakarta EE 11 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 **/mariadb_data
 **/nb-configuration.xml
+**/target

--- a/docker/database/docker-compose.yaml
+++ b/docker/database/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:18.1-alpine3.22
+    image: postgres:18.3-alpine3.22
     container_name: project_tracker_db
     environment:
       POSTGRES_USER: PROJECT_TRACKER

--- a/session-00-setup/.mvn/wrapper/maven-wrapper.properties
+++ b/session-00-setup/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-00-setup/README.md
+++ b/session-00-setup/README.md
@@ -42,7 +42,7 @@ Para evitar escribir el `pom.xml` de configuración desde cero, usaremos la herr
      - Profile: `Web Profile` (Es un buen punto de partida. Añadiremos más dependencias después).
    - Payara Platform
      - Payara Server
-     - Payara Platform version: `7.2025.2`
+     - Payara Platform version: `7.2026.3`
    - Project Configuration
      - Package: (el mismo de su Group ID)
      - No incluir Test
@@ -62,7 +62,7 @@ Lo más importante que ha generado esta herramienta está en tu [`pom.xml`](pom.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-00-setup/README.md
+++ b/session-00-setup/README.md
@@ -42,7 +42,7 @@ Para evitar escribir el `pom.xml` de configuración desde cero, usaremos la herr
      - Profile: `Web Profile` (Es un buen punto de partida. Añadiremos más dependencias después).
    - Payara Platform
      - Payara Server
-     - Payara Platform version: `7.2026.3`
+     - Payara Platform version: `7.2026.4`
    - Project Configuration
      - Package: (el mismo de su Group ID)
      - No incluir Test
@@ -62,7 +62,7 @@ Lo más importante que ha generado esta herramienta está en tu [`pom.xml`](pom.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-00-setup/pom.xml
+++ b/session-00-setup/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara7</payara.home>
     </properties>
     
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -68,7 +68,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-00-setup/pom.xml
+++ b/session-00-setup/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara7</payara.home>
     </properties>
     

--- a/session-01-jaxrs/.mvn/wrapper/maven-wrapper.properties
+++ b/session-01-jaxrs/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-01-jaxrs/pom.xml
+++ b/session-01-jaxrs/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara7</payara.home>
     </properties>
     
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -68,7 +68,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-01-jaxrs/pom.xml
+++ b/session-01-jaxrs/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara7</payara.home>
     </properties>
     

--- a/session-02-cdi/.mvn/wrapper/maven-wrapper.properties
+++ b/session-02-cdi/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-02-cdi/pom.xml
+++ b/session-02-cdi/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara7</payara.home>
     </properties>
     
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -68,7 +68,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-02-cdi/pom.xml
+++ b/session-02-cdi/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara7</payara.home>
     </properties>
     

--- a/session-03-jpa/.mvn/wrapper/maven-wrapper.properties
+++ b/session-03-jpa/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-03-jpa/pom.xml
+++ b/session-03-jpa/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -68,7 +68,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-03-jpa/pom.xml
+++ b/session-03-jpa/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-04-validation/.mvn/wrapper/maven-wrapper.properties
+++ b/session-04-validation/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-04-validation/pom.xml
+++ b/session-04-validation/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -68,7 +68,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-04-validation/pom.xml
+++ b/session-04-validation/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-05-data/.mvn/wrapper/maven-wrapper.properties
+++ b/session-05-data/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-05-data/pom.xml
+++ b/session-05-data/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -68,7 +68,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-05-data/pom.xml
+++ b/session-05-data/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-06-faces/.mvn/wrapper/maven-wrapper.properties
+++ b/session-06-faces/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-06-faces/pom.xml
+++ b/session-06-faces/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -54,12 +54,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -68,7 +68,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-06-faces/pom.xml
+++ b/session-06-faces/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-07-security/.mvn/wrapper/maven-wrapper.properties
+++ b/session-07-security/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-07-security/pom.xml
+++ b/session-07-security/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -73,12 +73,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -87,7 +87,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-07-security/pom.xml
+++ b/session-07-security/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-08-virtual_threads/.mvn/wrapper/maven-wrapper.properties
+++ b/session-08-virtual_threads/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-08-virtual_threads/pom.xml
+++ b/session-08-virtual_threads/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -73,12 +73,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -87,7 +87,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-08-virtual_threads/pom.xml
+++ b/session-08-virtual_threads/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-09-messaging/.mvn/wrapper/maven-wrapper.properties
+++ b/session-09-messaging/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-09-messaging/pom.xml
+++ b/session-09-messaging/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -80,12 +80,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -94,7 +94,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-09-messaging/pom.xml
+++ b/session-09-messaging/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-10-schedule/.mvn/wrapper/maven-wrapper.properties
+++ b/session-10-schedule/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-10-schedule/pom.xml
+++ b/session-10-schedule/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -80,12 +80,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -94,7 +94,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-10-schedule/pom.xml
+++ b/session-10-schedule/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-11-websockets/.mvn/wrapper/maven-wrapper.properties
+++ b/session-11-websockets/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-11-websockets/pom.xml
+++ b/session-11-websockets/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -80,12 +80,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -94,7 +94,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-11-websockets/pom.xml
+++ b/session-11-websockets/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-12-heath/.mvn/wrapper/maven-wrapper.properties
+++ b/session-12-heath/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-12-heath/pom.xml
+++ b/session-12-heath/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     
@@ -81,12 +81,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -95,7 +95,7 @@
             <plugin>
                     <groupId>fish.payara.maven.plugins</groupId>
                     <artifactId>payara-server-maven-plugin</artifactId>
-                    <version>1.0.0-Alpha3</version>
+                    <version>1.0.0-Alpha4</version>
                     <configuration>
                         <payaraServerVersion>${payara.version}</payaraServerVersion>
                     </configuration>

--- a/session-12-heath/pom.xml
+++ b/session-12-heath/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
     

--- a/session-13-batch/.mvn/wrapper/maven-wrapper.properties
+++ b/session-13-batch/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-13-batch/pom.xml
+++ b/session-13-batch/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
 
@@ -89,12 +89,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>fish.payara.maven.plugins</groupId>
                 <artifactId>payara-server-maven-plugin</artifactId>
-                <version>1.0.0-Alpha3</version>
+                <version>1.0.0-Alpha4</version>
                 <configuration>
                     <payaraServerVersion>${payara.version}</payaraServerVersion>
                 </configuration>

--- a/session-13-batch/pom.xml
+++ b/session-13-batch/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
 

--- a/session-14-container/.mvn/wrapper/maven-wrapper.properties
+++ b/session-14-container/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-14-container/Dockerfile
+++ b/session-14-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM payara/server-full:7.2025.2
+FROM payara/server-full:7.2026.3
 # 1. Copiar la App
 COPY target/project-tracker.war $DEPLOY_DIR
 

--- a/session-14-container/Dockerfile
+++ b/session-14-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM payara/server-full:7.2026.3
+FROM payara/server-full:7.2026.4
 # 1. Copiar la App
 COPY target/project-tracker.war $DEPLOY_DIR
 

--- a/session-14-container/README.md
+++ b/session-14-container/README.md
@@ -54,7 +54,7 @@ Este archivo es la "receta" para construir nuestra imagen.
 Crea un archivo llamado [`Dockerfile`](Dockerfile) (sin extensión) en la raíz del proyecto:
 
 ```dockerfile
-FROM payara/server-full:7.2025.2
+FROM payara/server-full:7.2026.3
 # 1. Copiar la App
 COPY target/project-tracker.war $DEPLOY_DIR
 

--- a/session-14-container/README.md
+++ b/session-14-container/README.md
@@ -54,7 +54,7 @@ Este archivo es la "receta" para construir nuestra imagen.
 Crea un archivo llamado [`Dockerfile`](Dockerfile) (sin extensión) en la raíz del proyecto:
 
 ```dockerfile
-FROM payara/server-full:7.2026.3
+FROM payara/server-full:7.2026.4
 # 1. Copiar la App
 COPY target/project-tracker.war $DEPLOY_DIR
 

--- a/session-14-container/pom.xml
+++ b/session-14-container/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
 
@@ -89,12 +89,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -103,7 +103,7 @@
             <plugin>
                 <groupId>fish.payara.maven.plugins</groupId>
                 <artifactId>payara-server-maven-plugin</artifactId>
-                <version>1.0.0-Alpha3</version>
+                <version>1.0.0-Alpha4</version>
                 <configuration>
                     <payaraServerVersion>${payara.version}</payaraServerVersion>
                 </configuration>

--- a/session-14-container/pom.xml
+++ b/session-14-container/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
 

--- a/session-15-payaramicro/.mvn/wrapper/maven-wrapper.properties
+++ b/session-15-payaramicro/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.6/apache-maven-3.9.6-bin.zip
-wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.2.0/maven-wrapper-3.2.0.jar
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/session-15-payaramicro/Dockerfile
+++ b/session-15-payaramicro/Dockerfile
@@ -1,4 +1,4 @@
-FROM payara/server-full:7.2025.2
+FROM payara/server-full:7.2026.3
 # 1. Copiar la App
 COPY target/project-tracker.war $DEPLOY_DIR
 

--- a/session-15-payaramicro/Dockerfile
+++ b/session-15-payaramicro/Dockerfile
@@ -1,4 +1,4 @@
-FROM payara/server-full:7.2026.3
+FROM payara/server-full:7.2026.4
 # 1. Copiar la App
 COPY target/project-tracker.war $DEPLOY_DIR
 

--- a/session-15-payaramicro/Dockerfile.micro
+++ b/session-15-payaramicro/Dockerfile.micro
@@ -1,5 +1,5 @@
 # 1. Usamos la imagen oficial de Payara Micro (JDK 21)
-FROM payara/micro:7.2025.2
+FROM payara/micro:7.2026.3
 
 # 2. Copiamos el WAR
 COPY target/project-tracker.war $DEPLOY_DIR

--- a/session-15-payaramicro/Dockerfile.micro
+++ b/session-15-payaramicro/Dockerfile.micro
@@ -1,5 +1,5 @@
 # 1. Usamos la imagen oficial de Payara Micro (JDK 21)
-FROM payara/micro:7.2026.3
+FROM payara/micro:7.2026.4
 
 # 2. Copiamos el WAR
 COPY target/project-tracker.war $DEPLOY_DIR

--- a/session-15-payaramicro/README.md
+++ b/session-15-payaramicro/README.md
@@ -66,7 +66,7 @@ Abre tu `pom.xml` y añade este plugin en la sección `<build><plugins>`:
     <artifactId>payara-micro-maven-plugin</artifactId>
     <version>2.4</version>
     <configuration>
-        <payaraVersion>7.2025.2</payaraVersion>
+        <payaraVersion>7.2026.3</payaraVersion>
         <deployWar>true</deployWar>
         <contextRoot>/</contextRoot>
         <postBootCommandFile>post-boot-commands.asadmin</postBootCommandFile>
@@ -166,7 +166,7 @@ Crea un archivo [`Dockerfile.micro`](Dockerfile.micro):
 
 ```dockerfile
 # 1. Usamos la imagen oficial de Payara Micro (JDK 21)
-FROM payara/micro:7.2025.2
+FROM payara/micro:7.2026.3
 
 # 2. Copiamos el WAR
 COPY target/project-tracker.war $DEPLOY_DIR

--- a/session-15-payaramicro/README.md
+++ b/session-15-payaramicro/README.md
@@ -66,7 +66,7 @@ Abre tu `pom.xml` y añade este plugin en la sección `<build><plugins>`:
     <artifactId>payara-micro-maven-plugin</artifactId>
     <version>2.4</version>
     <configuration>
-        <payaraVersion>7.2026.3</payaraVersion>
+        <payaraVersion>7.2026.4</payaraVersion>
         <deployWar>true</deployWar>
         <contextRoot>/</contextRoot>
         <postBootCommandFile>post-boot-commands.asadmin</postBootCommandFile>
@@ -166,7 +166,7 @@ Crea un archivo [`Dockerfile.micro`](Dockerfile.micro):
 
 ```dockerfile
 # 1. Usamos la imagen oficial de Payara Micro (JDK 21)
-FROM payara/micro:7.2026.3
+FROM payara/micro:7.2026.4
 
 # 2. Copiamos el WAR
 COPY target/project-tracker.war $DEPLOY_DIR

--- a/session-15-payaramicro/pom.xml
+++ b/session-15-payaramicro/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2025.2</payara.version>
+        <payara.version>7.2026.3</payara.version>
         <payara.home>payara</payara.home>
     </properties>
 
@@ -88,12 +88,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.5.1</version>
                 <configuration>
                     <failOnMissingWebXml>false</failOnMissingWebXml>
                 </configuration>
@@ -102,7 +102,7 @@
             <plugin>
                 <groupId>fish.payara.maven.plugins</groupId>
                 <artifactId>payara-server-maven-plugin</artifactId>
-                <version>1.0.0-Alpha3</version>
+                <version>1.0.0-Alpha4</version>
                 <configuration>
                     <payaraServerVersion>${payara.version}</payaraServerVersion>
                 </configuration>

--- a/session-15-payaramicro/pom.xml
+++ b/session-15-payaramicro/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>21</maven.compiler.release>
         <jakartaee-api.version>11.0.0</jakartaee-api.version>
-        <payara.version>7.2026.3</payara.version>
+        <payara.version>7.2026.4</payara.version>
         <payara.home>payara</payara.home>
     </properties>
 


### PR DESCRIPTION
### Changes in this pull request:

- Updated Payara version across all relevant files to `7.2026.4`.
- Upgraded various Maven plugins:
  - Maven Compiler Plugin: `3.15.0`
  - Maven War Plugin: `3.5.1`
  - Payara Server Maven Plugin: `1.0.0-Alpha4`
- Updated Maven Wrapper to use Maven `3.9.14`.
- Updated PostgreSQL Docker image to `18.3-alpine3.22`.
- Enhanced project structure with additional Jakarta EE 11 modules.
- Removed deprecated modules to ensure compatibility and clean architecture.
- Added `target` directory to `.gitignore` to prevent unnecessary revisions.
- General improvements to documentation and module refactoring.

Closes 14